### PR TITLE
Safety delay and remove serial mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,13 @@ No problems occured yet, let me know!
 - The pins for LEDs and buttons can be changed easily in the code
 - If you want to change the default state of the animation functionality, change line 42 to `bool animation = false;`. Note that the red LED will light up constantly from there.
 - The transition time (in ms) between states can be customized in line 32, 33 and 34
-- You can enable a "serial mode" in line 37, this will allow you to turn the lights on and off by sending "ON" or "OFF" (instead of setting the Relais-Pin high) via the serial monitor (no line ending!)
+- Delays to prevent false triggers can be changed in line 42 and 43
 - I've left some comments, feel free to edit the code so it fits your need
 
 ## Changelog
 - v1.0.2: Initial release (10.01.2023)
 - v1.1.0: See [Release Notes](https://github.com/fussel132/hue-controller/releases/v1.1.0) for details (15.01.2023)
+- v1.2.0: See [Release Notes](https://github.com/fussel132/hue-controller/releases/v1.2.0) for details (30.01.2023)
 
 ## Licence
 MIT License


### PR DESCRIPTION
### Version 1.2.0

- Added safety delays:
  - Pulldown resistors should prevent false signals to be picked up, however if installed in an electrical box there might still be false triggers.
  - This has been fixed by implementing safety delays for power off and the mode button
- Due to rewriting the section where input is registered, I've decided to scrap the serial mode. A future update will remove all serial functionality